### PR TITLE
Include GitHub Workflow that will automatically push to docker

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -3,7 +3,7 @@ name: Build And Push Docker Image
 on:
   push:
     branches:
-      - 'release'
+      - 'master'
 
 jobs:
   docker:

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'release'
-      - 'ryan-include-workflow-and-volumes'
 
 jobs:
   docker:
@@ -27,4 +26,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: msusel/pique-sbom-supply-chain-sec:test
+          tags: msusel/pique-sbom-supply-chain-sec:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,0 +1,30 @@
+name: Build And Push Docker Image
+
+on:
+  push:
+    branches:
+      - 'release'
+      - 'ryan-include-workflow-and-volumes'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: msusel/pique-sbom-supply-chain-sec:test


### PR DESCRIPTION
Note: Right now the only branch set up to do this is master.  Any time you push or merge a PR into master, this workflow will run and push the latest version of the docker image to DockerHub.  GH Actions has some powerful logic around what triggers workflows if we want more fine-grained control over when this runs. One more note, this uses my docker username and access token.  dockerhub free doesn't provide an "organization" credential so a user credential will have to do for now.